### PR TITLE
Allow 0 ResourceTableChunks and TypeSpecChunk to be null

### DIFF
--- a/java/com/google/devrel/gmscore/tools/apk/arsc/PackageChunk.java
+++ b/java/com/google/devrel/gmscore/tools/apk/arsc/PackageChunk.java
@@ -197,9 +197,15 @@ public class PackageChunk extends ChunkWithChunks {
     return typeSpecs.values();
   }
 
-  /** For a given (1-based) type id, returns the {@link TypeSpecChunk} matching it. */
+  /**
+   * For a given (1-based) type id, returns the {@link TypeSpecChunk} matching it.
+   */
   public TypeSpecChunk getTypeSpecChunk(int id) {
-    return Preconditions.checkNotNull(typeSpecs.get(id));
+    if (typeSpecs.containsKey(id)) {
+      return typeSpecs.get(id);
+    } else {
+      return null;
+    }
   }
 
   /**

--- a/java/com/google/devrel/gmscore/tools/apk/arsc/ResourceEntryStatsCollector.java
+++ b/java/com/google/devrel/gmscore/tools/apk/arsc/ResourceEntryStatsCollector.java
@@ -174,7 +174,9 @@ public class ResourceEntryStatsCollector {
       // The 1 here is to convert back to a 1-based index.
       TypeSpecChunk typeSpec = packageChunk.getTypeSpecChunk(i + 1);
       // TypeSpecChunk entries share everything equally.
-      addSizes(usages[i], typeSpec.getOriginalChunkSize(), 0, 1);
+      if (typeSpec != null) {
+        addSizes(usages[i], typeSpec.getOriginalChunkSize(), 0, 1);
+      }
     }
   }
 

--- a/java/com/google/devrel/gmscore/tools/apk/arsc/ResourceTableChunk.java
+++ b/java/com/google/devrel/gmscore/tools/apk/arsc/ResourceTableChunk.java
@@ -49,7 +49,7 @@ public class ResourceTableChunk extends ChunkWithChunks {
   protected ResourceTableChunk(ByteBuffer buffer, @Nullable Chunk parent) {
     super(buffer, parent);
     // packageCount. We ignore this, because we already know how many chunks we have.
-    Preconditions.checkState(buffer.getInt() >= 1, "ResourceTableChunk package count was < 1.");
+    Preconditions.checkState(buffer.getInt() >= 0, "ResourceTableChunk package count was < 0.");
   }
 
   @Override


### PR DESCRIPTION
When processing .apks outputted from `bundletool` I noticed that some would not process by `arscblamer` (and also don't work in the apk analyzer tool in Android Studio.

While debugging I found two issues that this PR is fixing

1. `ResourceTableChunk` checks if there is at least one entry. But there might be 0 entries (if this is e.g. a split apk for an abi split)
1. `TypeSpecChunk` can be `null` I have not found out the reason why but as it does handle the `null` check one layer up anyway, I am allowing it.

These two changes made our `.apks` process so I wanted to share this upstream.
